### PR TITLE
AWS sample_client python scripts

### DIFF
--- a/AWS/sample_client/check_tracking.py
+++ b/AWS/sample_client/check_tracking.py
@@ -73,12 +73,12 @@ def main() -> None:
             model_file_path = temp_dir_path / "model.pickle"
             with open(model_file_path, "wb") as f:
                 pickle.dump({"zupa": "grzybowa"}, f)
-            mlflow.log_artifact(model_file_path)
+            mlflow.log_artifact(str(model_file_path))
 
             image_file_path = temp_dir_path / "pony.png"
             with open(image_file_path, "wb") as f:
                 f.write(base64.b64decode(PONY))
-            mlflow.log_artifact(image_file_path)
+            mlflow.log_artifact(str(image_file_path))
     print("DONE")
 
 

--- a/AWS/sample_client/upload_model.py
+++ b/AWS/sample_client/upload_model.py
@@ -9,6 +9,13 @@ from load_values import load_env_values
 
 load_env_values(".env")
 
+try:
+    mlflow.create_experiment(os.environ["EXPERIMENT_NAME"], os.environ["BUCKET_URL"])
+except mlflow.MlflowException:
+    pass
+
+mlflow.set_experiment(os.environ["EXPERIMENT_NAME"])
+
 with mlflow.start_run():
     # load dataset and train model
     iris = load_iris()


### PR DESCRIPTION
- explicit string cast required with mlflow 2.9.0
- create and set experiment in upload_model as well